### PR TITLE
Force worker redeploy to clear cache

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -1,6 +1,7 @@
 /**
  * Cloudflare Worker for Zach's Terminal Website
  * Serves static files with caching and proper content types
+ * Version: 2024-11-05 - Cache-busting enabled
  */
 
 // Cache configuration


### PR DESCRIPTION
This tiny change triggers Cloudflare to redeploy the worker, which will clear the cached HTML and fetch fresh files from GitHub with the new cache-busting version numbers.