### PR TITLE
Temporarily disable HTML caching to force fresh content

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -56,11 +56,13 @@ export default {
       // But keep them in cache key for proper versioning
       const githubUrl = GITHUB_BASE + fileName;
 
-      // Check cache first
+      // Check cache first (TEMPORARILY DISABLED FOR HTML TO FORCE FRESH FETCH)
       const cache = caches.default;
       let response = await cache.match(request);
 
-      if (response) {
+      // Skip cache for HTML files to ensure fresh content
+      const isHtml = pathname === '/' || pathname.endsWith('.html');
+      if (response && !isHtml) {
         // Return cached response with cache hit header
         response = new Response(response.body, response);
         response.headers.set('X-Cache', 'HIT');


### PR DESCRIPTION
This bypasses the worker cache for HTML files, forcing it to fetch fresh content from GitHub on every request. Once the site updates properly, we can re-enable HTML caching.

CSS and JS files still use cache for performance.