### PR TITLE
Disable all caching in Cloudflare Worker

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -54,19 +54,12 @@ export default {
       // Build GitHub URL
       const githubUrl = GITHUB_BASE + fileName;
 
-      // Check cache first
-      const cache = caches.default;
-      let response = await cache.match(request);
+      // CACHING COMPLETELY DISABLED - Always fetch fresh from GitHub
+      // const cache = caches.default;
+      // let response = await cache.match(request);
 
-      if (response) {
-        // Return cached response with cache hit header
-        response = new Response(response.body, response);
-        response.headers.set('X-Cache', 'HIT');
-        return response;
-      }
-
-      // Fetch from GitHub
-      response = await fetch(githubUrl);
+      // Fetch from GitHub (bypassing cache entirely)
+      let response = await fetch(githubUrl);
 
       if (!response.ok) {
         // If file not found and it's root, try fetching Core.html as fallback
@@ -118,8 +111,8 @@ export default {
         headers: headers,
       });
 
-      // Store in cache for future requests
-      ctx.waitUntil(cache.put(request, modifiedResponse.clone()));
+      // Caching disabled - not storing in cache
+      // ctx.waitUntil(cache.put(request, modifiedResponse.clone()));
 
       return modifiedResponse;
     } catch (error) {


### PR DESCRIPTION
Completely disabled both cache lookup and cache storage to ensure all files (HTML, CSS, JS, images) are fetched fresh from GitHub on every request. This ensures immediate visibility of updates without requiring manual cache clearing or hard refreshes.