### PR TITLE
Remove terminal window styling for full-screen terminal

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,19 +45,6 @@
 
   <!-- Terminal Section -->
   <main class="terminal" id="terminal" style="display: none;" role="main">
-    <!-- Terminal Header -->
-    <div class="terminal-header">
-      <div class="terminal-buttons">
-        <button class="terminal-button btn-close" aria-label="Close"></button>
-        <button class="terminal-button btn-minimize" aria-label="Minimize"></button>
-        <button class="terminal-button btn-maximize" aria-label="Maximize"></button>
-      </div>
-      <div class="terminal-title">zach@zachbox: ~</div>
-      <div class="terminal-logo">KALI</div>
-    </div>
-
-    <!-- Terminal Body -->
-    <div class="terminal-body">
       <div class="output" role="status" aria-live="polite">
         <span class="info">Welcome to ZachBox Terminal v1.0</span>
       </div>
@@ -89,7 +76,6 @@
       <div id="terminalHelp" class="sr-only">
         Interactive terminal. Type 'help' for available commands. Use arrow keys to navigate command history. Press Tab for autocomplete.
       </div>
-    </div>
   </main>
 
   <!-- Main Script -->

--- a/script.js
+++ b/script.js
@@ -242,7 +242,7 @@ Buffalo, NY | Oct 2015 – Nov 2018, May 2023 – Nov 2023
 };
 
 // ====== DOM ELEMENTS ======
-let bootOutput, bootScreen, terminal, terminalBody, commandInput;
+let bootOutput, bootScreen, terminal, commandInput;
 
 // Command history for up/down arrow navigation
 let history = [];
@@ -258,11 +258,10 @@ function init() {
   bootOutput = document.getElementById('bootOutput');
   bootScreen = document.getElementById('bootScreen');
   terminal = document.getElementById('terminal');
-  terminalBody = document.querySelector('.terminal-body');
   commandInput = document.getElementById('commandInput');
 
   // Validate required elements exist
-  if (!bootOutput || !bootScreen || !terminal || !terminalBody || !commandInput) {
+  if (!bootOutput || !bootScreen || !terminal || !commandInput) {
     console.error('Required DOM elements not found');
     return;
   }
@@ -430,8 +429,8 @@ function addCommandLine(input) {
 
   // Find the input container and insert before it
   const inputContainer = commandInput.parentNode.parentNode;
-  terminalBody.insertBefore(promptTop, inputContainer);
-  terminalBody.insertBefore(promptBottom, inputContainer);
+  terminal.insertBefore(promptTop, inputContainer);
+  terminal.insertBefore(promptBottom, inputContainer);
   scrollToBottom();
 }
 
@@ -489,7 +488,7 @@ function typeOutput(text) {
   const outputDiv = document.createElement('div');
   outputDiv.className = 'output';
   const inputContainer = commandInput.parentNode.parentNode;
-  terminalBody.insertBefore(outputDiv, inputContainer);
+  terminal.insertBefore(outputDiv, inputContainer);
 
   let charIndex = 0;
   const interval = setInterval(() => {
@@ -513,7 +512,7 @@ function fakeLoading(callback) {
   loadingDiv.className = 'output';
   loadingDiv.innerText = CONFIG.LOADING_TEXT;
   const inputContainer = commandInput.parentNode.parentNode;
-  terminalBody.insertBefore(loadingDiv, inputContainer);
+  terminal.insertBefore(loadingDiv, inputContainer);
   scrollToBottom();
 
   setTimeout(() => {
@@ -526,7 +525,7 @@ function fakeLoading(callback) {
  * Clear the terminal and reset to initial state
  */
 function clearTerminal() {
-  const outputs = terminalBody.querySelectorAll('.output, .prompt-line:not(.prompt-line-top):not(:has(input)), .prompt-line-top');
+  const outputs = terminal.querySelectorAll('.output, .prompt-line:not(.prompt-line-top):not(:has(input)), .prompt-line-top');
 
   outputs.forEach(output => {
     // Don't remove the input container
@@ -548,7 +547,7 @@ function addStaticOutput(text) {
   div.className = 'output';
   div.innerHTML = text.replace(/\n/g, '<br>');
   const inputContainer = commandInput.parentNode.parentNode;
-  terminalBody.insertBefore(div, inputContainer);
+  terminal.insertBefore(div, inputContainer);
   scrollToBottom();
 }
 
@@ -556,7 +555,7 @@ function addStaticOutput(text) {
  * Scroll terminal to the bottom
  */
 function scrollToBottom() {
-  terminalBody.scrollTop = terminalBody.scrollHeight;
+  terminal.scrollTop = terminal.scrollHeight;
 }
 
 // ====== UTILITY FUNCTIONS ======

--- a/styles.css
+++ b/styles.css
@@ -58,31 +58,29 @@ body {
   flex-direction: column;
   min-height: 100vh;
   min-height: -webkit-fill-available;
-  padding: 20px;
+  padding: 0;
   /* Safe area for notched devices (iPhone X, etc.) */
-  padding-top: max(20px, env(safe-area-inset-top));
-  padding-bottom: max(20px, env(safe-area-inset-bottom));
-  padding-left: max(20px, env(safe-area-inset-left));
-  padding-right: max(20px, env(safe-area-inset-right));
+  padding-top: env(safe-area-inset-top);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
 }
 
-/* Terminal container styles - Kali Linux window */
+/* Terminal container styles - Full-screen terminal */
 .terminal, #bootScreen {
   flex: 1;
   display: flex;
   flex-direction: column;
-  padding: 0;
+  padding: var(--terminal-padding);
   border: none;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
-  overflow: hidden;
-  max-width: 1400px;
+  overflow-y: auto;
+  overflow-x: hidden;
   width: 100%;
-  height: auto;
-  min-height: 500px;
-  margin: 0 auto;
+  height: 100%;
+  margin: 0;
   background-color: var(--kali-bg-dark);
-  border-radius: 8px;
   -webkit-overflow-scrolling: touch;
+  scroll-behavior: smooth;
   /* Better text rendering on mobile */
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -95,63 +93,10 @@ body {
   overscroll-behavior: contain;
 }
 
-/* Terminal header - mimics Kali window title bar */
-.terminal-header {
-  background: var(--kali-header-bg);
-  padding: 10px 15px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  border-bottom: 2px solid var(--kali-purple);
-  flex-shrink: 0;
-}
-
-.terminal-buttons {
-  display: flex;
-  gap: 8px;
-}
-
-.terminal-button {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  border: none;
-  cursor: pointer;
-}
-
-.btn-close { background: #ff5f56; }
-.btn-minimize { background: #ffbd2e; }
-.btn-maximize { background: #27c93f; }
-
-.terminal-title {
-  color: #a0a0a0;
-  font-size: 13px;
-  flex: 1;
-  text-align: center;
-}
-
-.terminal-logo {
-  color: var(--kali-purple);
-  font-weight: bold;
-  font-size: 13px;
-  letter-spacing: 1px;
-}
-
-/* Terminal body content */
-.terminal-body {
-  flex: 1;
-  padding: var(--terminal-padding);
-  overflow-y: auto;
-  overflow-x: hidden;
-  scroll-behavior: smooth;
-}
-
 #bootScreen {
-  padding: var(--terminal-padding);
   white-space: pre-wrap;
   word-wrap: break-word;
   overflow-wrap: break-word;
-  overflow-y: auto;
   color: var(--primary-color);
 }
 
@@ -308,10 +253,6 @@ a:hover {
     --base-font-size: 15px;
     --terminal-padding: 24px;
   }
-
-  .terminal, #bootScreen {
-    max-width: 1400px;
-  }
 }
 
 /* Standard desktop */
@@ -319,10 +260,6 @@ a:hover {
   :root {
     --base-font-size: 14px;
     --terminal-padding: 20px;
-  }
-
-  .terminal, #bootScreen {
-    max-width: 1200px;
   }
 }
 
@@ -347,10 +284,6 @@ a:hover {
     --base-font-size: 15px;
   }
 
-  .terminal, #bootScreen {
-    border-radius: 4px;
-  }
-
   .output {
     margin-bottom: 10px;
   }
@@ -361,37 +294,6 @@ a:hover {
   :root {
     --base-font-size: 13px;
     --terminal-padding: 12px;
-  }
-
-  body {
-    padding: 10px;
-  }
-
-  .terminal, #bootScreen {
-    border-radius: 6px;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
-    min-height: 400px;
-  }
-
-  .terminal-header {
-    padding: 8px 12px;
-  }
-
-  .terminal-button {
-    width: 10px;
-    height: 10px;
-  }
-
-  .terminal-title {
-    font-size: 11px;
-  }
-
-  .terminal-logo {
-    font-size: 11px;
-  }
-
-  .terminal-body {
-    padding: 12px;
   }
 
   .output {


### PR DESCRIPTION
Changes:
- Removed terminal header with window control buttons
- Removed terminal-body wrapper div
- Removed all window-like styling (box-shadow, border-radius, max-width)
- Made terminal full-screen and edge-to-edge
- Updated JavaScript to use terminal element directly instead of terminal-body
- Kept Kali Linux colors and two-line fancy prompt
- Body padding set to 0 with only safe-area-insets for notched devices

Result: Clean full-screen terminal experience without window chrome