### PR TITLE
Fix broken commands by adding input-container wrapper

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 
   <!-- Stylesheet -->
-  <link rel="stylesheet" href="styles.css?v=20251106-kali-authentic">
+  <link rel="stylesheet" href="styles.css?v=20251106-fullscreen">
 
   <!-- Theme Color - Kali inspired -->
   <meta name="theme-color" content="#1e1e2e">
@@ -45,13 +45,15 @@
 
   <!-- Terminal Section -->
   <main class="terminal" id="terminal" style="display: none;" role="main">
-      <div class="output" role="status" aria-live="polite">
-        <span class="info">Welcome to ZachBox Terminal v1.0</span>
-      </div>
-      <div class="output" role="status">
-        Type <span class="highlight">help</span> to view available commands.
-      </div>
+    <div class="output" role="status" aria-live="polite">
+      <span class="info">Welcome to ZachBox Terminal v1.0</span>
+    </div>
+    <div class="output" role="status">
+      Type <span class="highlight">help</span> to view available commands.
+    </div>
 
+    <!-- Input Container for proper element insertion -->
+    <div class="input-container">
       <!-- Command Input Line with Kali-style fancy prompt -->
       <div class="prompt-line prompt-line-top">
         <span class="prompt-bracket">┌──(</span><span class="username">zach</span><span class="at-sign">@</span><span class="hostname">zachbox</span><span class="prompt-bracket">)-[</span><span class="path">~</span><span class="prompt-bracket">]</span>
@@ -76,9 +78,10 @@
       <div id="terminalHelp" class="sr-only">
         Interactive terminal. Type 'help' for available commands. Use arrow keys to navigate command history. Press Tab for autocomplete.
       </div>
+    </div>
   </main>
 
   <!-- Main Script -->
-  <script src="script.js?v=20251106-kali-authentic"></script>
+  <script src="script.js?v=20251106-fullscreen"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -100,6 +100,11 @@ body {
   color: var(--primary-color);
 }
 
+/* Input container - transparent wrapper for proper DOM structure */
+.input-container {
+  display: contents;
+}
+
 /* Kali-style two-line prompt */
 .prompt-line {
   display: flex;


### PR DESCRIPTION
Issue: Removed terminal-body broke JavaScript that relied on specific DOM structure Fix: Added input-container wrapper div with display:contents (invisible but maintains structure)
- JavaScript needs parent.parentNode to find insertion point
- display:contents makes container transparent in layout
- Updated cache-busting version to 20251106-fullscreen
- Commands now work correctly while maintaining full-screen appearance