### PR TITLE
Speed up boot sequence and fix display issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
 </head>
 <body>
   <!-- Boot Screen Section -->
-  <section id="bootScreen" role="region" aria-label="System boot sequence" aria-live="polite" style="display: none;">
+  <section id="bootScreen" role="region" aria-label="System boot sequence" aria-live="polite">
     <pre id="bootOutput" aria-label="Boot sequence output"></pre>
   </section>
 

--- a/script.js
+++ b/script.js
@@ -6,8 +6,8 @@
 // ====== CONSTANTS ======
 const CONFIG = {
   // Timing constants (in milliseconds)
-  BOOT_LINE_DELAY: 80,
-  LOADING_DELAY: 300,
+  BOOT_LINE_DELAY: 15,  // Reduced from 80ms for faster boot
+  LOADING_DELAY: 200,   // Reduced from 300ms
   TYPING_SPEED: 2,
 
   // Colors (matched with CSS variables - Kali theme)


### PR DESCRIPTION
Changes:
- Reduced BOOT_LINE_DELAY from 80ms to 15ms (~75% faster boot)
- Reduced LOADING_DELAY from 300ms to 200ms
- Fixed boot screen not appearing (removed display:none from initial state)
- Boot sequence now completes in ~1 second instead of 4+ seconds

Total boot time: ~1 second (was ~4-5 seconds)