### PR TITLE
Fix prompt line breaks with explicit inline display

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 
   <!-- Stylesheet -->
-  <link rel="stylesheet" href="styles.css?v=20251106-fullscreen">
+  <link rel="stylesheet" href="styles.css?v=20251106-v2">
 
   <!-- Theme Color - Kali inspired -->
   <meta name="theme-color" content="#1e1e2e">
@@ -82,6 +82,6 @@
   </main>
 
   <!-- Main Script -->
-  <script src="script.js?v=20251106-fullscreen"></script>
+  <script src="script.js?v=20251106-v2"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -110,7 +110,8 @@ body {
   display: flex;
   align-items: center;
   margin-bottom: 5px;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
+  white-space: nowrap;
 }
 
 .prompt-line-top {
@@ -118,6 +119,16 @@ body {
 }
 
 /* Prompt components with Kali colors */
+.prompt-bracket,
+.username,
+.at-sign,
+.hostname,
+.path,
+.prompt-symbol {
+  display: inline;
+  white-space: nowrap;
+}
+
 .prompt-bracket {
   color: var(--kali-purple);
 }


### PR DESCRIPTION
Issue: Prompt elements breaking to separate lines after commands/clear Fix:
- Added explicit display: inline to all prompt components
- Changed flex-wrap: wrap to flex-wrap: nowrap
- Added white-space: nowrap to prevent line breaks
- Updated cache-busting version to v2 to force fresh CSS/JS load

This ensures prompt displays correctly as:
┌──(user@zachbox)-[~]
└─$

Instead of each element on its own line.