### PR TITLE
Add Snake game easter egg

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,6 +82,6 @@
   </main>
 
   <!-- Main Script -->
-  <script src="script.js?v=20251106-eastereggs"></script>
+  <script src="script.js?v=20251106-snake"></script>
 </body>
 </html>


### PR DESCRIPTION
Added a fully playable Snake game to the terminal!

Features:
- Type 'snake' to launch the game
- Use arrow keys to control the snake
- Press ESC to quit anytime
- 30x15 grid with smooth gameplay
- Score tracking (+10 points per food)
- Snake grows when eating food (red diamonds)
- Game over on wall collision or self-collision
- Kali-themed colors:
  - Cyan (●) for snake head
  - Green (○) for snake body
  - Red (◆) for food
- Box-drawing characters for clean borders
- Command input disabled during gameplay
- Auto-cleanup when game ends

Easter eggs now include:
1. sudo [command] - Random permission denied jokes
2. msfconsole/metasploit - Fake Metasploit console
3. snake - Classic snake game!

Updated cache-busting version to force JS reload.