### PR TITLE
Add vim simulator and rm -rf / easter eggs

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,6 +82,6 @@
   </main>
 
   <!-- Main Script -->
-  <script src="script.js?v=20251106-snake-v2"></script>
+  <script src="script.js?v=20251106-vim-rm"></script>
 </body>
 </html>


### PR DESCRIPTION
Added two new interactive easter eggs:

1. rm -rf / or rm -rf /* - Dangerous command warning:
   - Shows big red warning when attempting to delete root
   - Displays realistic error message about failsafe
   - Explains consequences with humor
   - Educational about dangerous Linux commands

2. vim / vi - Full vim simulator:
   - Realistic vim interface with tildes (~) on empty lines
   - Status bar showing "portfolio.txt [Modified]"
   - Command mode activated with ':'
   - Working commands:
     * :q - Quit
     * :q! - Force quit * :wq - Save and quit * :x - Save and exit * :w - Write/save * :help - Show help
   - Live command buffer display
   - Proper vim error messages (E492: Not an editor command)
   - ESC cancels command mode
   - Backspace works in command mode
   - Keyboard input disabled for terminal during vim
   - Auto-cleanup on exit
   - Fun exit messages and pro tips

Easter eggs collection now includes:
1. sudo [command] - Permission denied jokes
2. msfconsole/metasploit - Fake Metasploit console
3. snake - Classic snake game
4. rm -rf / - Dangerous command warning
5. vim/vi - Vim simulator

Updated cache-busting version to force JS reload.