### PR TITLE
Fix directory prompt update and cat command display

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,6 +82,6 @@
   </main>
 
   <!-- Main Script -->
-  <script src="script.js?v=20251106-filesystem"></script>
+  <script src="script.js?v=20251106-cat-fix"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1487,8 +1487,8 @@ function catFile(fileName) {
     return;
   }
 
-  // Display file contents
-  typeOutput(file.content);
+  // Display file contents immediately (like real cat command)
+  addStaticOutput(file.content);
 }
 
 /**
@@ -1498,6 +1498,12 @@ function updatePromptPath() {
   // Update the CONFIG.PATH to show current directory
   const shortPath = currentPath.replace('/home/user', '~');
   CONFIG.PATH = shortPath;
+
+  // Update the visible prompt in the input area
+  const pathSpan = document.querySelector('.input-container .path');
+  if (pathSpan) {
+    pathSpan.textContent = shortPath;
+  }
 }
 
 // ====== MATRIX EFFECT ======


### PR DESCRIPTION
- Update prompt path immediately when changing directories
- Change cat command to display content instantly (like real cat)
- Update cache-busting version for both fixes